### PR TITLE
Binary reader cleanup / fix issues

### DIFF
--- a/Word2vec.Tools.Example/Program.cs
+++ b/Word2vec.Tools.Example/Program.cs
@@ -47,7 +47,7 @@ namespace Word2vec.Tools.Example
 
             #region analogy
             Console.WriteLine("\""+girl+"\" relates to \""+boy+"\" as \""+woman+"\" relates to ..."); 
-            var analogies = vocabulary.Analogy("girl", "boy", "woman", count);
+            var analogies = vocabulary.Analogy(girl, boy, woman, count);
             foreach (var neightboor in analogies)
                 Console.WriteLine(neightboor.Representation.Word + "\t\t" + neightboor.Distance);
             #endregion
@@ -65,8 +65,8 @@ namespace Word2vec.Tools.Example
             Console.WriteLine();
 
             #region subtraction
-             Console.WriteLine("\"girl\" - \"boy\" = ...");
-             var subtractionRepresentation = vocabulary["girl"].Substract(vocabulary["boy"]);
+			 Console.WriteLine("\""+girl+"\" - \""+boy+"\" = ...");
+             var subtractionRepresentation = vocabulary[girl].Substract(vocabulary[boy]);
              var closestSubtractions = vocabulary.Distance(subtractionRepresentation, count);
              foreach (var neightboor in closestSubtractions)
                  Console.WriteLine(neightboor.Representation.Word + "\t\t" + neightboor.Distance);

--- a/Word2vec.Tools/Word2VecTextReader.cs
+++ b/Word2vec.Tools/Word2VecTextReader.cs
@@ -15,16 +15,40 @@ namespace Word2vec.Tools
         {
             using (var strStream = new System.IO.StreamReader(inputStream))
             {
-                var firstLine = strStream.ReadLine().Split(' ');
-                var vocabularySize = int.Parse(firstLine[0]);
-                var vectorSize = int.Parse(firstLine[1]);
+                bool isFirstLine = true;
+                int vocabularySize = 0;
+                int vectorSize = -1;
 
-                var vectors = new List<WordRepresentation>(vocabularySize);
+                //var firstLine = strStream.ReadLine().Split(' ');
+
+                var vectors = new List<WordRepresentation>();
 
                 var enUsCulture = CultureInfo.GetCultureInfo("en-US");
                 while (!strStream.EndOfStream)
                 {
                     var line = strStream.ReadLine().Split(' ');
+                    if (isFirstLine) {
+                        if (line.Length == 2) {
+                            try {
+                                //header
+                                vocabularySize = int.Parse(line[0]);
+                                vectorSize = int.Parse(line[1]);
+                                vectors = new List<WordRepresentation>(vocabularySize);
+                                continue; 
+                            } catch {
+                                vocabularySize = 0;
+                                vectorSize = -1;
+                            }
+                        }
+
+                        if (vectorSize == -1) {
+                            // no header, so require all other vectors to match first line's length
+                            vectorSize = line.Length - 1;
+                        }
+
+                        isFirstLine = false;
+                    }
+
                     var vecs = line.Skip(1).Take(vectorSize).ToArray();
                     if (vecs.Length != vectorSize)
                         throw new FormatException("word \"" + line.First() + "\" has wrong vector size of " + vecs.Length);


### PR DESCRIPTION
I've cleaned up `Word2VecBinaryReader`. I was running into a couple of issues:

\1. It seems `PeekChar()` [does not work](http://stackoverflow.com/a/22690936/443019) on Binary streams. This was causing an error when reading `GoogleNews-vectors-negative300.bin`. After 1763820 entries around the word "Deseray" I'd get this:

> Unhandled Exception: System.ArgumentException: The output char buffer is too small to contain the decoded characters, encoding 'Unicode (UTF-8)' fallback 'System.Text.DecoderReplacementFallback'.

This is now fixed, and the file now reads.

\2. Some binary streams don't support get_Position() (`readerSream.BaseStream.Position`). In particular `GZipStream`. So by removing the need for this it's now possible to parse .gz files without decompressing them to disk first.

So now, to read a .bin.gz without decompressing it first, for example:

```
string path = @"c:\datasets\GoogleNews-vectors-negative300.bin.gz";
FileInfo fileToDecompress = new FileInfo(path);
FileStream originalFileStream = fileToDecompress.OpenRead();
GZipStream decompressionStream = new GZipStream(originalFileStream, CompressionMode.Decompress);
var vocabulary = new Word2VecBinaryReader().Read(decompressionStream);
```

Cheers

Peter.
